### PR TITLE
Fixed bug that forced loading events and views from pre-defined folder

### DIFF
--- a/src/Moneta/MonetaSdkUtils.php
+++ b/src/Moneta/MonetaSdkUtils.php
@@ -112,11 +112,11 @@ class MonetaSdkUtils
 	public static function requireView($viewName, $data, $externalPath = null)
 	{
         $result = false;
-        if (!$externalPath && $externalPath != '') {
-            $viewFileName = __DIR__ . $externalPath . $viewName . '.php';
+        if (empty($externalPath)) {
+            $viewFileName = __DIR__ . self::VIEW_FILES_PATH . $viewName . '.php';
         }
         else {
-            $viewFileName = __DIR__ . self::VIEW_FILES_PATH . $viewName . '.php';
+            $viewFileName = __DIR__ . $externalPath . $viewName . '.php';
         }
 		if (file_exists($viewFileName)) {
             ob_start();
@@ -137,11 +137,11 @@ class MonetaSdkUtils
     public static function handleEvent($eventName, $data, $externalPath = null)
     {
         $result = false;
-        if (!$externalPath && $externalPath != '') {
-            $eventFileName = __DIR__ . $externalPath . $eventName . '.php';
+        if (empty($externalPath)) {
+            $eventFileName = __DIR__ . self::EVENTS_FILES_PATH . $eventName . '.php';
         }
         else {
-            $eventFileName = __DIR__ . self::EVENTS_FILES_PATH . $eventName . '.php';
+            $eventFileName = __DIR__ . $externalPath . $eventName . '.php';
         }
         if (file_exists($eventFileName)) {
             require($eventFileName);


### PR DESCRIPTION
[english version below]

Из-за некорректной проверки, код, который загружает View/Event, всегда загружает его из self::VIEW_FILES_PATH / self::EVENTS_FILES_PATH - даже в случае, когда передаешь корректный externalPath.
Исправил проверку на empty.

Due to incorrect check of externalPath variable, Views and Events are loaded from self::vIEW_FILES_PATH and self::EVENTS_FILES_PATH even when externalPath is passed into the function and is not null.
I've fixed the bug and replaced the check with simple "empty", which does the thing just fine.